### PR TITLE
Adding no-check-if-disabled option

### DIFF
--- a/bootstrap.validator.js
+++ b/bootstrap.validator.js
@@ -67,6 +67,11 @@
                 var equals = self.attr('data-equals');
                 var value = self.val();
 
+                // Check if the user has activated no-check-if-disabled
+                if (self.attr('no-check-if-disabled') && self.is(":disabled")){
+                    return;
+                }
+
                 if(self.is("[type='checkbox']") && !self.is(":checked")) value='';
 
                 // replace value with total value


### PR DESCRIPTION
Added the option 'no-check-if-disabled'. If set to true, the element is not checked if it is disabled.

Useful for disabling fragments of a form ang ignoring them when the form is validated.
